### PR TITLE
Add support for getting media url for download link

### DIFF
--- a/pikpakapi/__init__.py
+++ b/pikpakapi/__init__.py
@@ -615,7 +615,7 @@ class PikPakApi:
         2. Use `web_content_link` to download the file
         """
         result = await self._request_get(
-            url=f"https://{self.PIKPAK_API_HOST}/drive/v1/files/{id}?_magic=2021&thumbnail_size=SIZE_LARGE",
+            url=f"https://{self.PIKPAK_API_HOST}/drive/v1/files/{file_id}?_magic=2021&thumbnail_size=SIZE_LARGE",
         )
         return result
 

--- a/pikpakapi/__init__.py
+++ b/pikpakapi/__init__.py
@@ -606,15 +606,16 @@ class PikPakApi:
             result = await self.file_batch_copy(ids=from_ids, to_parent_id=to_parent_id)
         return result
 
-    async def get_download_url(self, id: str) -> Dict[str, Any]:
+    async def get_download_url(self, file_id: str) -> Dict[str, Any]:
         """
         id: str - 文件id
 
-        获取文件的下载链接
-        返回结果中的 web_content_link 字段
+        Returns the file details data.
+        1. Use `medias[0][link][url]` for streaming with high speed in streaming services or tools.
+        2. Use `web_content_link` to download the file
         """
         result = await self._request_get(
-            url=f"https://{self.PIKPAK_API_HOST}/drive/v1/files/{id}?usage=FETCH",
+            url=f"https://{self.PIKPAK_API_HOST}/drive/v1/files/{id}?_magic=2021&thumbnail_size=SIZE_LARGE",
         )
         return result
 


### PR DESCRIPTION
Users are complaining that the `web_content_link` is getting speed capped. While when they use it via alist, they get high speed. So i checked alist code and grab the link from their code https://github.com/alist-org/alist/blob/main/drivers/pikpak/driver.go#L80, which is using `result["medias"][0]["link"]["url"]` for playing the stream.